### PR TITLE
Constrained operations which rely on ordering to only overload when their values can be totally_ordered

### DIFF
--- a/P1928/changelog.tex
+++ b/P1928/changelog.tex
@@ -60,6 +60,7 @@
 \item Overload loads and stores with mask argument (\ref{sec:simd.ctor}, \ref{sec:simd.copy}, \ref{sec:simd.mask.ctor}, \ref{sec:simd.mask.copy}).
 \item Respecify \simd reductions to use a \mask argument instead of \code{const_where_expression} (\ref{sec:simd.reductions}).
 \item Add \mask operators returning a \simd (\ref{sec:simd.mask.unary}, \ref{sec:simd.mask.conv})
+\item Constrain some functions (e.g., min, max, clamp) to be \code{totally_ordered} (\ref{sec:simd.reductions}, \ref{sec:simd.alg}).
   \todo Replace \code{where} wording.
   \todo Apply the new library specification style from P0788R3.
   \todo Add \code{numeric_limits} / numeric traits specializations since behavior of e.g. \code{simd<float>} and \code{float} may differ for reasonable implementations.

--- a/P1928/main.tex
+++ b/P1928/main.tex
@@ -289,7 +289,7 @@ Previously some operators (e.g., \code{operator<}) and functions which relied on
 some property of the element type (e.g., \tcode{min} relies on ordering)
 were unconstrained. Operations which were not permitted on individual elements
 were still available in the overload set for simd objects of those types.
-Constraints have been added were necessary to remove such operators and
+Constraints have been added where necessary to remove such operators and
 functions from the overload set where they aren't supported.
 
 \section{Open questions}

--- a/P1928/main.tex
+++ b/P1928/main.tex
@@ -283,6 +283,15 @@ Summary:
 
 For a discussion of this topic see \wglink{P1928R3} Section 5.2.
 
+\subsection{Added constraints on operators and functions to match their underlying element types}
+
+Previously some operators (e.g., \code{operator<}) and functions which relied on
+some property of the element type (e.g., \tcode{min} relies on ordering)
+were unconstrained. Operations which were not permitted on individual elements
+were still available in the overload set for simd objects of those types.
+Constraints have been added were necessary to remove such operators and
+functions from the overload set where they aren't supported.
+
 \section{Open questions}
 
 \subsection{Alternatives to \code{hmin} and \code{hmax}}

--- a/P1928/wording.tex
+++ b/P1928/wording.tex
@@ -1345,6 +1345,8 @@ template<class T, class Abi> constexpr T hmin(const simd<T, Abi>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
   \pnum\returns
   The value of an element \tcode{x[$j$]} for which \tcode{x[$i$] < x[$j$]} is \tcode{false} \foralli.
 \end{itemdescr}
@@ -1355,6 +1357,8 @@ template<class T, class Abi>
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
   \pnum\returns
   If \tcode{none_of(mask)}, returns \tcode{numeric_limits<T>::max()}.
   Otherwise, returns the value of a selected element \tcode{x[$j$]} for which \tcode{x[$i$] < x[$j$]} is \tcode{false} \forallmaskedi.
@@ -1365,6 +1369,8 @@ template<class T, class Abi> constexpr T hmax(const simd<T, Abi>& x) noexcept;
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
   \pnum\returns
   The value of an element \tcode{x[$j$]} for which \tcode{x[$j$] < x[$i$]} is \tcode{false} \foralli.
 \end{itemdescr}
@@ -1375,6 +1381,9 @@ template<class T, class Abi>
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
+
   \pnum\returns
   If \tcode{none_of(mask)}, returns \tcode{numeric_limits<V::value_type>::lowest()}.
   Otherwise, returns the value of a selected element \tcode{x.data[$j$]} for which \tcode{x.data[$j$] < x.data[$i$]} is \tcode{false} \forallmaskedi.
@@ -1472,6 +1481,8 @@ template<class T, class Abi> constexpr simd<T, Abi> min(const simd<T, Abi>& a, c
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
   \pnum\returns
   The result of the element-wise application of \tcode{std::min(a[$i$], b[$i$])} \foralli.
 \end{itemdescr}
@@ -1481,6 +1492,8 @@ template<class T, class Abi> constexpr simd<T, Abi> max(const simd<T, Abi>& a, c
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
   \pnum\returns
   The result of the element-wise application of \tcode{std::max(a[$i$], b[$i$])} \foralli.
 \end{itemdescr}
@@ -1491,6 +1504,8 @@ template<class T, class Abi>
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
   \pnum\returns
   A \tcode{pair} initialized with
   \begin{itemize}
@@ -1505,6 +1520,8 @@ template<class T, class Abi> simd<T, Abi>
 \end{itemdecl}
 
 \begin{itemdescr}
+  \pnum\constraints
+  \tcode{totally_ordered<T>} is \tcode{true}
   \pnum\requires
   No element in \tcode{lo} shall be greater than the corresponding element in \tcode{hi}.
 

--- a/P1928/wording.tex
+++ b/P1928/wording.tex
@@ -1346,7 +1346,11 @@ template<class T, class Abi> constexpr T hmin(const simd<T, Abi>& x) noexcept;
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
+
   \pnum\returns
   The value of an element \tcode{x[$j$]} for which \tcode{x[$i$] < x[$j$]} is \tcode{false} \foralli.
 \end{itemdescr}
@@ -1358,7 +1362,11 @@ template<class T, class Abi>
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
+
   \pnum\returns
   If \tcode{none_of(mask)}, returns \tcode{numeric_limits<T>::max()}.
   Otherwise, returns the value of a selected element \tcode{x[$j$]} for which \tcode{x[$i$] < x[$j$]} is \tcode{false} \forallmaskedi.
@@ -1370,7 +1378,11 @@ template<class T, class Abi> constexpr T hmax(const simd<T, Abi>& x) noexcept;
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
+
   \pnum\returns
   The value of an element \tcode{x[$j$]} for which \tcode{x[$j$] < x[$i$]} is \tcode{false} \foralli.
 \end{itemdescr}
@@ -1382,7 +1394,10 @@ template<class T, class Abi>
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
 
   \pnum\returns
   If \tcode{none_of(mask)}, returns \tcode{numeric_limits<V::value_type>::lowest()}.
@@ -1482,7 +1497,11 @@ template<class T, class Abi> constexpr simd<T, Abi> min(const simd<T, Abi>& a, c
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
+
   \pnum\returns
   The result of the element-wise application of \tcode{std::min(a[$i$], b[$i$])} \foralli.
 \end{itemdescr}
@@ -1493,7 +1512,11 @@ template<class T, class Abi> constexpr simd<T, Abi> max(const simd<T, Abi>& a, c
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
+
   \pnum\returns
   The result of the element-wise application of \tcode{std::max(a[$i$], b[$i$])} \foralli.
 \end{itemdescr}
@@ -1505,7 +1528,11 @@ template<class T, class Abi>
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
+
   \pnum\returns
   A \tcode{pair} initialized with
   \begin{itemize}
@@ -1521,7 +1548,11 @@ template<class T, class Abi> simd<T, Abi>
 
 \begin{itemdescr}
   \pnum\constraints
-  \tcode{totally_ordered<T>} is \tcode{true}
+  \tcode{T} satisfies \tcode{totally_ordered}.
+
+  \pnum\expects
+  \tcode{T} models \tcode{totally_ordered}.
+
   \pnum\requires
   No element in \tcode{lo} shall be greater than the corresponding element in \tcode{hi}.
 


### PR DESCRIPTION
Not sure whether this is really the right wording, but it captures where suitable wording needs to be added. 

Alternative wording could be to say that `min` is constrained by having `operator<` defined for T, but `simd::min` doesn't actually have to be implemented in terms of `operator<` at all. T::value_type doesn't have to define `operator<` either, and wouldn't be implemented in terms of `operator<(value_type, value_type)` either. The constraint is really on whether it makes sense to compare to value_types in a mathemetical sense, rather than something that actually provides all the right operators, but I'm not sure of the best way to say that.